### PR TITLE
Fix unsupported language warning

### DIFF
--- a/src/Map.ts
+++ b/src/Map.ts
@@ -951,7 +951,7 @@ export class Map extends maplibregl.Map {
     const language = toLanguageInfo(lang, Language);
 
     if (!language) {
-      console.warn(`The language "${language}" is not supported.`);
+      console.warn(`The language "${lang}" is not supported.`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- fix language warning message to include the provided language name

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6834991286a88329aa8420f788995997